### PR TITLE
Potential fix for code scanning alert no. 1: Unsafe jQuery plugin

### DIFF
--- a/wwwroot/lib/jquery-validation/dist/jquery.validate.js
+++ b/wwwroot/lib/jquery-validation/dist/jquery.validate.js
@@ -686,7 +686,7 @@ $.extend( $.validator, {
 		},
 
 		clean: function( selector ) {
-			return $( selector )[ 0 ];
+			return jQuery.find(selector)[ 0 ];
 		},
 
 		errors: function() {


### PR DESCRIPTION
Potential fix for [https://github.com/Denis-Raduica/AcademIQ/security/code-scanning/1](https://github.com/Denis-Raduica/AcademIQ/security/code-scanning/1)

To fix the issue, the `clean` function should ensure that the `selector` parameter is treated strictly as a CSS selector and not as HTML. This can be achieved by using `jQuery.find` instead of `$`. The `find` method interprets the input as a CSS selector and does not evaluate it as HTML, mitigating the risk of XSS.

**Steps to fix:**
1. Replace the use of `$` in the `clean` function with `jQuery.find`.
2. Ensure that the `selector` parameter is validated or sanitized before being passed to `find`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
