### PR TITLE
Potential fix for code scanning alert no. 3: Unsafe HTML constructed from library input

### DIFF
--- a/wwwroot/lib/jquery/dist/jquery.js
+++ b/wwwroot/lib/jquery/dist/jquery.js
@@ -1275,10 +1275,21 @@ function setDocument( node ) {
 
 		var input;
 
-		documentElement.appendChild( el ).innerHTML =
-			"<a id='" + expando + "' href='' disabled='disabled'></a>" +
-			"<select id='" + expando + "-\r\\' disabled='disabled'>" +
-			"<option selected=''></option></select>";
+		var anchor = document.createElement("a");
+		anchor.setAttribute("id", expando);
+		anchor.setAttribute("href", "");
+		anchor.setAttribute("disabled", "disabled");
+
+		var select = document.createElement("select");
+		select.setAttribute("id", expando + "-\r\\");
+		select.setAttribute("disabled", "disabled");
+
+		var option = document.createElement("option");
+		option.setAttribute("selected", "");
+		select.appendChild(option);
+
+		el.appendChild(anchor);
+		el.appendChild(select);
 
 		// Support: iOS <=7 - 8 only
 		// Boolean attributes and "value" are not treated correctly in some XML documents


### PR DESCRIPTION
Potential fix for [https://github.com/Denis-Raduica/AcademIQ/security/code-scanning/3](https://github.com/Denis-Raduica/AcademIQ/security/code-scanning/3)

To fix the issue, we need to ensure that the dynamic HTML construction on line 1279 in `wwwroot/lib/jquery/dist/jquery.js` is safe. This can be achieved by avoiding the use of `innerHTML` and instead using safer DOM manipulation methods, such as `createElement` and `appendChild`. These methods allow us to construct the DOM elements programmatically without exposing the application to XSS risks.

Specifically:
1. Replace the `innerHTML` assignment with code that creates the `<a>` and `<select>` elements programmatically.
2. Ensure that the `id` attributes and other properties are set using safe APIs like `setAttribute`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
